### PR TITLE
Fix Michigan page details and add navigation link test

### DIFF
--- a/carter-ellis-website-FINAL-NO-GMAIL-BELOW (1)/app.html
+++ b/carter-ellis-website-FINAL-NO-GMAIL-BELOW (1)/app.html
@@ -52,7 +52,7 @@
       "The Wolverines lead the all-time series against more than half of the current Big Ten.",
       "Their fight song, 'The Victors,' is widely considered the best in college football.",
       "Michigan was the first team to wear winged helmets in 1938 under Coach Fritz Crisler.",
-      "The program has claimed 11 national championships.",
+      "The program has claimed 12 national championships.",
       "Michigan holds the record for the most all-time winning seasons (120+)."
     ];
     function showFact() {

--- a/carter-ellis-website-FINAL-NO-GMAIL-BELOW (1)/index.html
+++ b/carter-ellis-website-FINAL-NO-GMAIL-BELOW (1)/index.html
@@ -72,7 +72,7 @@
 <div>
 <a href="index.html">Home</a>
 <a href="resume.html">Resume</a>
-<a href="michigan-facts.html">Michigan Football</a>
+<a href="scratch.html">Michigan Football</a>
 </div>
 </div>
 <img alt="Carter Ellis" class="profile-img" src="photo.jpg"/>

--- a/carter-ellis-website-FINAL-NO-GMAIL-BELOW (1)/scratch.html
+++ b/carter-ellis-website-FINAL-NO-GMAIL-BELOW (1)/scratch.html
@@ -37,7 +37,7 @@
         <li><strong>Produced 3 Heisman Trophy winners</strong> – Tom Harmon, Desmond Howard, Charles Woodson</li>
         <li><strong>Over 400 NFL draftees</strong> – including Tom Brady, Charles Woodson, Aidan Hutchinson</li>
         <li><strong>Iconic coaches</strong> – Fielding Yost, Bo Schembechler, Lloyd Carr, Jim Harbaugh</li>
-        <li><strong>Massive, passionate fanbase</strong> – consistently leads nation in average attendance</li>
+        <li><strong>Massive, passionate fanbase</strong> – consistently leads the nation in average attendance</li>
         <li><strong>Elite academics + athletics</strong> – regularly ranked top public university with top-tier sports</li>
       </ul>
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "carterellis24.github.io",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/tests/navLinks.test.js
+++ b/tests/navLinks.test.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+const path = require('path');
+const test = require('node:test');
+const assert = require('node:assert');
+
+const siteDir = path.join(__dirname, '..', 'carter-ellis-website-FINAL-NO-GMAIL-BELOW (1)');
+const html = fs.readFileSync(path.join(siteDir, 'index.html'), 'utf8');
+
+const linkRegex = /<a\s+[^>]*href="([^"]+)"/g;
+const links = [];
+let match;
+while ((match = linkRegex.exec(html)) !== null) {
+  links.push(match[1]);
+}
+
+const internalLinks = links.filter(href => !href.startsWith('http') && !href.startsWith('#'));
+
+internalLinks.forEach(link => {
+  test(`"${link}" points to existing file`, () => {
+    const filePath = path.join(siteDir, link);
+    assert.ok(fs.existsSync(filePath), `Missing file for link: ${link}`);
+  });
+});


### PR DESCRIPTION
## Summary
- Fix navigation to point Michigan Football menu item to existing page.
- Correct Michigan fanbase bullet and update national championship count.
- Add Node-based navigation link test and configure `npm test`.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68952cef02148323a0982881caaa86e8